### PR TITLE
Fix typo in backend comment

### DIFF
--- a/backend/server.js
+++ b/backend/server.js
@@ -52,7 +52,7 @@ if (process.env.NODE_ENV === 'production') {
 //the following router is for displaying the class labels
 
 //following route is for displaying the list of students
-//according to the classses
+//according to the classes
 
 //following route will only be used in case the error is encountered.
 //FOLLOWING IS THE FALL BACK ROUTE for url not listed in the backend folder


### PR DESCRIPTION
## Summary
- fix comment typo from `classses` to `classes`

## Testing
- `grep -n classs backend/server.js`

------
https://chatgpt.com/codex/tasks/task_e_68478f60d3a4832682fb6d17f55afeb8