### PR TITLE
Fix seeder export call

### DIFF
--- a/backend/seeder.js
+++ b/backend/seeder.js
@@ -60,7 +60,7 @@ const exportData = async () => {
 }
 
 if (process.argv[2] === '-d') {
-  destroyData()
+  exportData()
 } else {
   importData()
 }


### PR DESCRIPTION
## Summary
- fix the destroy data call in `backend/seeder.js`

## Testing
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_68478f6153188326a4ca7adea88d7247